### PR TITLE
refactor: reimplementation makeQueryHelper (include BREAKING CHANGES!)

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -4,7 +4,7 @@
   "commit": false,
   "linked": [],
   "access": "restricted",
-  "baseBranch": "master",
+  "baseBranch": "main",
   "updateInternalDependencies": "patch",
   "ignore": []
 }

--- a/.changeset/new-pianos-cheat.md
+++ b/.changeset/new-pianos-cheat.md
@@ -1,0 +1,5 @@
+---
+'react-query-helper': minor
+---
+
+Reimplement makeQueryHelper

--- a/README.md
+++ b/README.md
@@ -1,29 +1,44 @@
-# react-query-helper
+# React Query Helper
 
 [![npm version](https://badge.fury.io/js/react-query-helper.svg)](https://badge.fury.io/js/react-query-helper) ![npm bundle size](https://img.shields.io/bundlephobia/min/react-query-helper) ![npm bundle size](https://img.shields.io/bundlephobia/minzip/react-query-helper) [![Test](https://github.com/dano-inc/react-query-helper/actions/workflows/test.yml/badge.svg?branch=main)](https://github.com/dano-inc/react-query-helper/actions/workflows/test.yml) [![codecov](https://codecov.io/gh/dano-inc/react-query-helper/branch/main/graph/badge.svg?token=TD9B2BKN24)](https://codecov.io/gh/dano-inc/react-query-helper) ![GitHub](https://img.shields.io/github/license/dano-inc/react-query-helper)
 
-A helper library to use react-query more efficient, consistency
-
-## Problems
-
-I've been using react-query for 2-3 years. In most situations, I used it to manage the remote server state.
-However, managing the Query Keys and matching the Query Data type manually was quite tiring.
-Sometimes, It makes me sad when the query data type that I inferred manually is not equal with the actual query data type.
+A helper library to help you use [React Query](https://react-query.tanstack.com/) more easily and consistently.
 
 ## Features
 
 - **Write query key once, use everywhere.** you don't have to remember something's query key; the query key will be generated with your baseQueryKey and arguments of queryFn that you were called as defined
 - **Written in TypeScript.** you can infer your query result type/interface.
 
+## Why?
+
+I've been using React Query for 2-3 years. In most situations, I used to make a custom hook and manage query keys as constant strings. but it was quite tiring.
+
+Sometimes, It makes me sad when the query data type that I inferred manually is not equal with the actual query data type. for example:
+
+```ts
+// Set query's data.
+queryClient.setQueryData([queryKeys.product.all], [{}] as IProductList);
+
+// It is unknown type:
+queryClient.getQueryData([queryKeys.product.all]);
+
+// Okay, we know we can use generic type but we can also make a mistake.
+// These mistakes are quite hard to find.
+queryClient.getQueryData<IProduct>([queryKeys.product.all]);
+queryClient.getQueryData<IProductList>([queryKeys.category.all]);
+```
+
+Essentially, Making a custom hook using useQuery or managing Query Keys as constants strings are not guaranteed your query result type. so you have to infer types manually like `queryClient.getQueryData<IProductList>` or you'll get `unknown` type as result.
+
 ## Installation
 
-> NOTE: react-query-helper depends on react-query as a **peer** dependency.
+> NOTE: This libary depends on React Query as a **peer** dependency.
 
 ```bash
-$ yarn add react-query-helper
+$ yarn add react-query react-query-helper
 
 # or npm:
-$ npm install react-query-helper
+$ npm install react-query react-query-helper
 ```
 
 ## Usage
@@ -47,15 +62,13 @@ export const getUserById = makeQueryHelper({
 });
 ```
 
-Now you can make a hook that type-safe `useQuery` with `createUseQuery` and get or set query data type-safety.
+Now you can use type-safe `useQuery` and get or set query data type-safety.
 
 ```tsx
 import { getUserById } from '../remotes/getUserById';
 
-const useGetUserById = getUserById.createUseQuery();
-
 const UserInfo: FC = () => {
-  const { data } = useGetUserById(1);
+  const { data } = getUserById.useQuery(1);
 
   return <p>name: {data?.name}</p>;
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-query-helper",
-  "description": "A helper library to use react-query more efficient, consistency",
+  "description": "A helper library to help you use React Query more easily and consistently.",
   "license": "MIT",
   "keywords": [
     "react-query",

--- a/src/makeQueryHelper.test.ts
+++ b/src/makeQueryHelper.test.ts
@@ -64,10 +64,9 @@ const getPostById = makeQueryHelper({
     (id: number): Post => ({ id, title: `Post#${id}` }),
 });
 
-describe('createUseQuery', () => {
+describe('useQuery', () => {
   it('should call useQuery with queryKey based on argument', () => {
-    const useGetPostById = getPostById.createUseQuery();
-    useGetPostById(1);
+    getPostById.useQuery(1);
 
     expect(mockUseQuery.mock.calls).toMatchInlineSnapshot(`
       Array [
@@ -85,8 +84,7 @@ describe('createUseQuery', () => {
   });
 
   it('should call useQuery with options from last argument', () => {
-    const useGetPostById = getPostById.createUseQuery();
-    useGetPostById(2, { enabled: true, suspense: true });
+    getPostById.useQuery(2, { enabled: true, suspense: true });
 
     expect(mockUseQuery.mock.calls).toMatchInlineSnapshot(`
       Array [
@@ -104,35 +102,11 @@ describe('createUseQuery', () => {
       ]
     `);
   });
-
-  it('should call useQuery with default query options and options from last argument', () => {
-    const useGetPostById = getPostById.createUseQuery({ cacheTime: 1000 });
-    useGetPostById(3, { meta: { type: 'test' } });
-
-    expect(mockUseQuery.mock.calls).toMatchInlineSnapshot(`
-      Array [
-        Array [
-          Object {
-            "cacheTime": 1000,
-            "meta": Object {
-              "type": "test",
-            },
-            "queryFn": [Function],
-            "queryKey": Array [
-              "post",
-              3,
-            ],
-          },
-        ],
-      ]
-    `);
-  });
 });
 
-describe('createUseInfiniteQuery', () => {
+describe('useInfiniteQuery', () => {
   it('should call useInfiniteQuery with queryKey based on argument', () => {
-    const useGetPosts = getPosts.createUseInfiniteQuery();
-    useGetPosts();
+    getPosts.useInfiniteQuery();
 
     expect(mockUseInfiniteQuery.mock.calls).toMatchInlineSnapshot(`
       Array [
@@ -149,8 +123,7 @@ describe('createUseInfiniteQuery', () => {
   });
 
   it('should call useInfiniteQuery with options from last argument', () => {
-    const useGetPosts = getPosts.createUseInfiniteQuery();
-    useGetPosts({ enabled: true, suspense: true });
+    getPosts.useInfiniteQuery({ enabled: true, suspense: true });
 
     expect(mockUseInfiniteQuery.mock.calls).toMatchInlineSnapshot(`
       Array [
@@ -167,34 +140,11 @@ describe('createUseInfiniteQuery', () => {
       ]
     `);
   });
-
-  it('should call useInfiniteQuery with default query options and options from last argument', () => {
-    const useGetPosts = getPosts.createUseInfiniteQuery({ cacheTime: 1000 });
-    useGetPosts({ meta: { type: 'test' } });
-
-    expect(mockUseInfiniteQuery.mock.calls).toMatchInlineSnapshot(`
-      Array [
-        Array [
-          Object {
-            "cacheTime": 1000,
-            "meta": Object {
-              "type": "test",
-            },
-            "queryFn": [Function],
-            "queryKey": Array [
-              "posts",
-            ],
-          },
-        ],
-      ]
-    `);
-  });
 });
 
-describe('createUseIsFetching', () => {
+describe('useIsFetching', () => {
   it('should call useIsFetching with queryKey based on argument', () => {
-    const useGetPostByIdIsFetching = getPostById.createUseIsFetching();
-    useGetPostByIdIsFetching(1);
+    getPostById.useIsFetching(1);
 
     expect(mockUseIsFetching.mock.calls).toMatchInlineSnapshot(`
       Array [
@@ -210,8 +160,7 @@ describe('createUseIsFetching', () => {
   });
 
   it('should call useIsFetching with filters from last argument', () => {
-    const useGetPostByIdIsFetching = getPostById.createUseIsFetching();
-    useGetPostByIdIsFetching(1, { exact: true });
+    getPostById.useIsFetching(1, { exact: true });
 
     expect(mockUseIsFetching.mock.calls).toMatchInlineSnapshot(`
       Array [
@@ -222,28 +171,6 @@ describe('createUseIsFetching', () => {
           ],
           Object {
             "exact": true,
-          },
-        ],
-      ]
-    `);
-  });
-
-  it('should call useIsFetching with default query filters and filters from last argument', () => {
-    const useGetPostByIdIsFetching = getPostById.createUseIsFetching({
-      stale: true,
-    });
-    useGetPostByIdIsFetching(1, { exact: true });
-
-    expect(mockUseIsFetching.mock.calls).toMatchInlineSnapshot(`
-      Array [
-        Array [
-          Array [
-            "post",
-            1,
-          ],
-          Object {
-            "exact": true,
-            "stale": true,
           },
         ],
       ]
@@ -539,6 +466,7 @@ describe('getInfiniteQueryData', () => {
 
 describe('getQueriesData', () => {
   beforeEach(async () => {
+    await getPosts.prefetchQuery();
     await getPostById.prefetchQuery(1);
     await getPostById.prefetchQuery(2);
     await getPostById.prefetchQuery(3);
@@ -549,7 +477,10 @@ describe('getQueriesData', () => {
   });
 
   it('should get queries what matching with filter', () => {
-    const queryFilterPredicate = (query: Query) => query.queryKey[1] !== 3;
+    const queryFilterPredicate = (query: Query) => {
+      return query.queryKey[0] === 'post' && query.queryKey[1] !== 3;
+    };
+
     expect(
       getPostById.getQueriesData({ predicate: queryFilterPredicate }).length
     ).toBe(2);
@@ -587,7 +518,7 @@ describe('setQueryData', () => {
       { id: 2, title: 'bar' },
     ]);
 
-    expect(getPosts.getQueryData(undefined)).toMatchInlineSnapshot(`
+    expect(getPosts.getQueryData()).toMatchInlineSnapshot(`
       Array [
         Object {
           "id": 1,
@@ -649,7 +580,7 @@ describe('setInfiniteQueryData', () => {
       pages: [[{ id: 1, title: 'foo' }], [{ id: 2, title: 'bar' }]],
     });
 
-    expect(getPosts.getQueryData(undefined)).toMatchInlineSnapshot(`
+    expect(getPosts.getQueryData()).toMatchInlineSnapshot(`
       Object {
         "pageParams": Array [],
         "pages": Array [
@@ -676,7 +607,7 @@ describe('setInfiniteQueryData', () => {
       pages: [[{ id: 1, title: 'foo' }], [{ id: 2, title: 'bar' }]],
     });
 
-    expect(getPosts.getQueryData(undefined)).toMatchInlineSnapshot(`
+    expect(getPosts.getQueryData()).toMatchInlineSnapshot(`
       Object {
         "pageParams": Array [],
         "pages": Array [
@@ -765,7 +696,7 @@ describe('setQueriesData', () => {
   it('should update each queries data', () => {
     getPostById.setQueriesData((cache: Post | undefined) => {
       cache!.title = `Modified ${cache!.title}`;
-      return cache as Post;
+      return cache;
     });
 
     expect(getPostById.getQueryData(1)).toMatchInlineSnapshot(`

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,141 @@
+import type {
+  CancelOptions,
+  FetchInfiniteQueryOptions,
+  FetchQueryOptions,
+  InfiniteData,
+  InvalidateOptions,
+  InvalidateQueryFilters,
+  QueryClient,
+  QueryKey,
+  RefetchOptions,
+  RefetchQueryFilters,
+  ResetOptions,
+  ResetQueryFilters,
+  SetDataOptions,
+  UseInfiniteQueryOptions,
+  UseInfiniteQueryResult,
+  useIsFetching,
+  UseQueryOptions,
+  UseQueryResult,
+} from 'react-query';
+import { QueryState } from 'react-query/types/core/query';
+import { QueryFilters, Updater } from 'react-query/types/core/utils';
+
+export interface TypedQueryClient<
+  TQueryFnArgs extends unknown[] = [],
+  TQueryFnData = unknown,
+  TError = unknown,
+  TData = TQueryFnData,
+  TQueryKey extends QueryKey = QueryKey
+> {
+  isFetching(filters?: QueryFilters): number;
+  fetchQuery(
+    ...args: [
+      ...args: TQueryFnArgs,
+      options?: FetchQueryOptions<TQueryFnData, TError, TData, TQueryKey>
+    ]
+  ): Promise<TData>;
+  prefetchQuery(
+    ...args: [
+      ...args: TQueryFnArgs,
+      options?: FetchQueryOptions<TQueryFnData, TError, TData, TQueryKey>
+    ]
+  ): Promise<void>;
+  fetchInfiniteQuery(
+    ...args: [
+      ...args: TQueryFnArgs,
+      options?: FetchInfiniteQueryOptions<
+        TQueryFnData,
+        TError,
+        TData,
+        TQueryKey
+      >
+    ]
+  ): Promise<InfiniteData<TData>>;
+  prefetchInfiniteQuery(
+    ...args: [
+      ...args: TQueryFnArgs,
+      options?: FetchInfiniteQueryOptions<
+        TQueryFnData,
+        TError,
+        TData,
+        TQueryKey
+      >
+    ]
+  ): Promise<void>;
+  getQueryData(
+    ...args: [...args: TQueryFnArgs, filters?: QueryFilters]
+  ): TData | undefined;
+  getQueriesData(filters?: QueryFilters): [QueryKey, TData][];
+  setQueryData(
+    ...args: [
+      ...args: TQueryFnArgs,
+      updater: Updater<TData | undefined, TData | undefined>,
+      options?: SetDataOptions
+    ]
+  ): TData;
+  setQueriesData(
+    updater: Updater<TData | undefined, TData | undefined>
+  ): [QueryKey, TData][];
+  getQueryState(
+    ...args: [...args: TQueryFnArgs, filters?: QueryFilters]
+  ): QueryState<TData, TError> | undefined;
+  invalidateQueries<TPageData = unknown>(
+    filters?: InvalidateQueryFilters<TPageData>,
+    options?: InvalidateOptions
+  ): Promise<void>;
+  refetchQueries<TPageData = unknown>(
+    filters?: RefetchQueryFilters<TPageData>,
+    options?: RefetchOptions
+  ): Promise<void>;
+  cancelQueries(filters?: QueryFilters, options?: CancelOptions): Promise<void>;
+  removeQueries(filters?: QueryFilters): void;
+  resetQueries<TPageData = unknown>(
+    filters?: ResetQueryFilters<TPageData>,
+    options?: ResetOptions
+  ): Promise<void>;
+
+  // Custom
+  withQueryClient(
+    queryClient: QueryClient
+  ): TypedQueryClient<TQueryFnArgs, TQueryFnData, TError>;
+  setInfiniteQueriesData(
+    updater: Updater<
+      InfiniteData<TData> | undefined,
+      InfiniteData<TData> | undefined
+    >
+  ): [QueryKey, InfiniteData<TData>][];
+  getInfiniteQueriesData(
+    filters?: QueryFilters
+  ): [QueryKey, InfiniteData<TData>][];
+  setInfiniteQueryData(
+    ...args: [
+      ...args: TQueryFnArgs,
+      updater: Updater<
+        InfiniteData<TData> | undefined,
+        InfiniteData<TData> | undefined
+      >,
+      options?: SetDataOptions
+    ]
+  ): InfiniteData<TData>;
+  getInfiniteQueryData(
+    ...args: [...args: TQueryFnArgs, filters?: QueryFilters]
+  ): InfiniteData<TData> | undefined;
+
+  // Hooks
+  useIsFetching(
+    ...args: [...args: TQueryFnArgs, filters?: QueryFilters]
+  ): number;
+  useQuery(
+    ...args: [
+      ...args: TQueryFnArgs,
+      filters?: UseQueryOptions<TQueryFnData, TError>
+    ]
+  ): UseQueryResult<TData, TError>;
+  useInfiniteQuery(
+    ...args: [
+      ...args: TQueryFnArgs,
+      filters?: UseInfiniteQueryOptions<TQueryFnData, TError>
+    ]
+  ): UseInfiniteQueryResult<TData, TError>;
+}


### PR DESCRIPTION
- Instead of implementing some methods to ensure type-safe, use proxy and write a separate type declaration. it allowed reduced lines of codes and bundle size. 
- `createUseQuery`, `createUseInfiniteQuery`, `createUseIsFetching` are removed.
- `useQuery`, `useInfiniteQuery`, `useIsFetching` are added. using hook options clearly is better than implicit.

Snapshot version: `0.0.0-test-202111311831`

To-Do
- [x] Update README.md (add FAQ or Why? section)
- [ ] Update Examples

close #6 